### PR TITLE
Remove unnecessary usage of `static mut`

### DIFF
--- a/src/fragile.rs
+++ b/src/fragile.rs
@@ -7,8 +7,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use crate::errors::InvalidThreadAccess;
 
 fn next_thread_id() -> usize {
-    static mut COUNTER: AtomicUsize = AtomicUsize::new(0);
-    unsafe { COUNTER.fetch_add(1, Ordering::SeqCst) }
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    COUNTER.fetch_add(1, Ordering::SeqCst)
 }
 
 pub(crate) fn get_thread_id() -> usize {

--- a/src/sticky.rs
+++ b/src/sticky.rs
@@ -9,8 +9,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use crate::errors::InvalidThreadAccess;
 
 fn next_item_id() -> usize {
-    static mut COUNTER: AtomicUsize = AtomicUsize::new(0);
-    unsafe { COUNTER.fetch_add(1, Ordering::SeqCst) }
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    COUNTER.fetch_add(1, Ordering::SeqCst)
 }
 
 type RegistryMap = HashMap<usize, (UnsafeCell<*mut ()>, Box<dyn Fn(&UnsafeCell<*mut ()>)>)>;


### PR DESCRIPTION
There's no need for `unsafe` here, atomics only need `&self`.