### PR TITLE
Use a `Slab` as the sticky registry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ repository = "https://github.com/mitsuhiko/fragile"
 homepage = "https://github.com/mitsuhiko/fragile"
 keywords = ["send", "cell", "non-send", "send-wrapper", "failure"]
 edition = "2018"
+
+[dependencies]
+slab = "0.4.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ mod errors;
 mod fragile;
 mod semisticky;
 mod sticky;
+mod thread_id;
 
 pub use crate::errors::InvalidThreadAccess;
 pub use crate::fragile::Fragile;

--- a/src/thread_id.rs
+++ b/src/thread_id.rs
@@ -1,0 +1,11 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn next() -> usize {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    COUNTER.fetch_add(1, Ordering::SeqCst)
+}
+
+pub(crate) fn get() -> usize {
+    thread_local!(static THREAD_ID: usize = next());
+    THREAD_ID.with(|&x| x)
+}


### PR DESCRIPTION
Using a `Slab` instead of a `HashMap` should have much lower overhead, because we don't have to go through the whole hashing mechanism. The only disadvantage is that now each `Sticky` has to also hold its thread ID, but that isn't too much of a big deal.

Merging this would also close #13, since it happens to implement it at the same time.