### PR TITLE
Use `NonZeroUsize` to store thread IDs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ repository = "https://github.com/mitsuhiko/fragile"
 homepage = "https://github.com/mitsuhiko/fragile"
 keywords = ["send", "cell", "non-send", "send-wrapper", "failure"]
 edition = "2018"
+
+[dependencies]
+slab = "0.4.5"

--- a/src/fragile.rs
+++ b/src/fragile.rs
@@ -2,6 +2,7 @@ use std::cmp;
 use std::fmt;
 use std::mem;
 use std::mem::MaybeUninit;
+use std::num::NonZeroUsize;
 
 use crate::errors::InvalidThreadAccess;
 use crate::thread_id;
@@ -16,7 +17,7 @@ use crate::thread_id;
 /// not going to panic but might temporarily leak the value.
 pub struct Fragile<T> {
     value: MaybeUninit<Box<T>>,
-    thread_id: usize,
+    thread_id: NonZeroUsize,
 }
 
 impl<T> Fragile<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ mod errors;
 mod fragile;
 mod semisticky;
 mod sticky;
+mod thread_id;
 
 pub use crate::errors::InvalidThreadAccess;
 pub use crate::fragile::Fragile;

--- a/src/sticky.rs
+++ b/src/sticky.rs
@@ -3,6 +3,7 @@ use std::cmp;
 use std::fmt;
 use std::marker::PhantomData;
 use std::mem;
+use std::num::NonZeroUsize;
 
 use slab::Slab;
 
@@ -35,7 +36,7 @@ thread_local!(static REGISTRY: UnsafeCell<Registry> = UnsafeCell::new(Registry(S
 /// of destructors for TLS apply.
 pub struct Sticky<T> {
     item_id: usize,
-    thread_id: usize,
+    thread_id: NonZeroUsize,
     _marker: PhantomData<*mut T>,
 }
 

--- a/src/thread_id.rs
+++ b/src/thread_id.rs
@@ -1,0 +1,11 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn next() -> usize {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    COUNTER.fetch_add(1, Ordering::SeqCst)
+}
+
+pub(crate) fn get() -> usize {
+    thread_local!(static THREAD_ID: usize = next());
+    THREAD_ID.with(|&x| x)
+}

--- a/src/thread_id.rs
+++ b/src/thread_id.rs
@@ -1,11 +1,12 @@
+use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-fn next() -> usize {
-    static COUNTER: AtomicUsize = AtomicUsize::new(0);
-    COUNTER.fetch_add(1, Ordering::SeqCst)
+fn next() -> NonZeroUsize {
+    static COUNTER: AtomicUsize = AtomicUsize::new(1);
+    NonZeroUsize::new(COUNTER.fetch_add(1, Ordering::SeqCst)).expect("more than usize::MAX threads")
 }
 
-pub(crate) fn get() -> usize {
-    thread_local!(static THREAD_ID: usize = next());
+pub(crate) fn get() -> NonZeroUsize {
+    thread_local!(static THREAD_ID: NonZeroUsize = next());
     THREAD_ID.with(|&x| x)
 }


### PR DESCRIPTION
This PR builds on #17 for convenience (as that PR adds thread IDs to `Sticky<T>` and changes where thread IDs are declared) but I would be happy to apply it to master also. 

This allows the Rust compiler to treat zero as a niche for `Fragile<T>` and `Sticky<T>`, making types like `Option<Sticky<T>>` 16 bytes instead of 24.