### PR TITLE
Simplify pointer manipulation in sticky registry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ repository = "https://github.com/mitsuhiko/fragile"
 homepage = "https://github.com/mitsuhiko/fragile"
 keywords = ["send", "cell", "non-send", "send-wrapper", "failure"]
 edition = "2018"
+
+[dependencies]
+slab = "0.4.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ mod errors;
 mod fragile;
 mod semisticky;
 mod sticky;
+mod thread_id;
 
 pub use crate::errors::InvalidThreadAccess;
 pub use crate::fragile::Fragile;

--- a/src/thread_id.rs
+++ b/src/thread_id.rs
@@ -1,0 +1,11 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn next() -> usize {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    COUNTER.fetch_add(1, Ordering::SeqCst)
+}
+
+pub(crate) fn get() -> usize {
+    thread_local!(static THREAD_ID: usize = next());
+    THREAD_ID.with(|&x| x)
+}


### PR DESCRIPTION
Once again I'm building on #17, because otherwise we'd end up with annoying merge conflicts.

This change makes the pointer manipulation used in the sticky registry more obviously correct in my opinion. Registry entries are now just uses a simple pair of named pointers with documented semantics. There are fewer places where we have to deal with pointers-to-pointers, and fewer "sigils soups" like `Box::from_raw(*(cell.get() as *mut *mut T))`. We also avoid dodgy things like transmuting `&UnsafeCell<*mut ()>` to `&UnsafeCell<Box<T>>`. The whole `UnsafeCell` thing wasn't necessary to begin with, since there's no interior mutability used - although the value can be accessed mutably, it's only when we have `&mut self` so it's fine.

As a side effect we avoid heap-allocating functions for each registry entry, so that's nice.