### PR TITLE
Fine-tune the Ordering for COUNTER 

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -57,7 +57,7 @@ mod map_impl {
 
     fn next_item_id() -> NonZeroUsize {
         static COUNTER: AtomicUsize = AtomicUsize::new(1);
-        NonZeroUsize::new(COUNTER.fetch_add(1, Ordering::SeqCst))
+        NonZeroUsize::new(COUNTER.fetch_add(1, Ordering::Relaxed))
             .expect("more than usize::MAX items")
     }
 

--- a/src/thread_id.rs
+++ b/src/thread_id.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 fn next() -> NonZeroUsize {
     static COUNTER: AtomicUsize = AtomicUsize::new(1);
-    NonZeroUsize::new(COUNTER.fetch_add(1, Ordering::SeqCst)).expect("more than usize::MAX threads")
+    NonZeroUsize::new(COUNTER.fetch_add(1, Ordering::Relaxed)).expect("more than usize::MAX threads")
 }
 
 pub(crate) fn get() -> NonZeroUsize {


### PR DESCRIPTION
https://github.com/mitsuhiko/fragile/blob/b079b3c2a0402e8f6758f39d4c38ec6453dac85f/src/registry.rs#L58-L62
https://github.com/mitsuhiko/fragile/blob/b079b3c2a0402e8f6758f39d4c38ec6453dac85f/src/thread_id.rs#L4-L7
Here `COUNTER` is employed solely for counting purposes, rather than for synchronizing access to other shared variables. While `SeqCst` guarantees program correctness, it can also impact performance. Therefore, using `Relaxed` is sufficient to maintain the program's correctness without adversely affecting its efficiency.